### PR TITLE
Add "force downgrade" (client) and "prefer downgrade" (server) options

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -17,10 +17,11 @@ package client
 import "google.golang.org/grpc"
 
 type connectOptions struct {
-	dialOpts     []grpc.DialOption
-	extraH2ALPNs []string
-	forceHTTP2   bool
-	useWebSocket bool
+	dialOpts       []grpc.DialOption
+	extraH2ALPNs   []string
+	forceHTTP2     bool
+	forceDowngrade bool
+	useWebSocket   bool
 }
 
 // ConnectOption is an option that can be passed to the `ConnectViaProxy` method.
@@ -57,6 +58,14 @@ func UseWebSocket(use bool) ConnectOption {
 	return useWebSocketOption(use)
 }
 
+// ForceDowngrade returns a connection option that instructs the
+// client to always force gRPC-Web downgrade for gRPC requests.
+// Client- or Bidi-streaming requests will not work.
+// This option has no effect if websockets are being used.
+func ForceDowngrade(force bool) ConnectOption {
+	return forceDowngradeOption(force)
+}
+
 type dialOptsOption []grpc.DialOption
 
 func (o dialOptsOption) apply(opts *connectOptions) {
@@ -79,4 +88,10 @@ type useWebSocketOption bool
 
 func (o useWebSocketOption) apply(opts *connectOptions) {
 	opts.useWebSocket = bool(o)
+}
+
+type forceDowngradeOption bool
+
+func (o forceDowngradeOption) apply(opts *connectOptions) {
+	opts.forceDowngrade = bool(o)
 }

--- a/internal/grpcweb/defs.go
+++ b/internal/grpcweb/defs.go
@@ -19,4 +19,10 @@ const (
 	trailerMessageFlag byte = 1 << 7
 
 	completeHeaderLen = 5
+
+	// GRPCWebOnlyHeader is a header to indicate that the server should always return gRPC-Web
+	// responses, regardless of detected client capabilities. The presence of the header alone
+	// is sufficient, however it is recommended that a client chooses "true" as the only value
+	// whenver the header is used.
+	GRPCWebOnlyHeader = `Grpc-Web-Only`
 )

--- a/internal/grpcweb/defs_test.go
+++ b/internal/grpcweb/defs_test.go
@@ -1,0 +1,12 @@
+package grpcweb
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGRPCWebOnlyHeaderNameIsCanonical(t *testing.T) {
+	assert.Equal(t, GRPCWebOnlyHeader, http.CanonicalHeaderKey(GRPCWebOnlyHeader))
+}

--- a/server/options.go
+++ b/server/options.go
@@ -1,0 +1,24 @@
+package server
+
+type options struct {
+	preferGRPCWeb bool
+}
+
+// Option is an object that controls the behavior of the downgrading gRPC server.
+type Option interface {
+	apply(o *options)
+}
+
+type optionFunc func(o *options)
+
+func (f optionFunc) apply(o *options) {
+	f(o)
+}
+
+// PreferGRPCWeb instructs the server to always send a downgraded gRPC-Web response
+// if the client indicates it accepts gRPC-Web responses.
+func PreferGRPCWeb(prefer bool) Option {
+	return optionFunc(func(o *options) {
+		o.preferGRPCWeb = prefer
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -178,7 +178,7 @@ func CreateDowngradingHandler(grpcSrv *grpc.Server, httpHandler http.Handler, op
 			return
 		}
 
-		if contentType, _ := stringutils.Split2(req.Header.Get("Content-Type"), "+"); contentType != "application/grpc" && contentType != "application/grpc-web" {
+		if contentType, _ := stringutils.Split2(req.Header.Get("Content-Type"), "+"); contentType != "application/grpc" {
 			// Non-gRPC request to the same port.
 			httpHandler.ServeHTTP(w, req)
 			return

--- a/server/server.go
+++ b/server/server.go
@@ -93,10 +93,12 @@ func handleGRPCWS(w http.ResponseWriter, req *http.Request, grpcSrv *grpc.Server
 	_ = conn.Close(websocket.StatusNormalClosure, "")
 }
 
-func handleGRPCWeb(w http.ResponseWriter, req *http.Request, validPaths map[string]struct{}, grpcSrv *grpc.Server) {
+func handleGRPCWeb(w http.ResponseWriter, req *http.Request, validPaths map[string]struct{}, grpcSrv *grpc.Server, srvOpts *options) {
+	_, isDowngradableMethod := validPaths[req.URL.Path]
+
 	// Check for HTTP/2.
 	if req.ProtoMajor != 2 {
-		if _, ok := validPaths[req.URL.Path]; !ok {
+		if !isDowngradableMethod {
 			// Client-streaming only works with HTTP/2.
 			http.Error(w, "Method cannot be downgraded", http.StatusInternalServerError)
 			return
@@ -104,17 +106,34 @@ func handleGRPCWeb(w http.ResponseWriter, req *http.Request, validPaths map[stri
 		req.ProtoMajor, req.ProtoMinor, req.Proto = 2, 0, "HTTP/2.0"
 	}
 
-	if req.Header.Get("TE") == "trailers" {
-		// Yay, client accepts trailers! Let the normal gRPC handler handle the request.
+	acceptedContentTypes := strings.FieldsFunc(strings.Join(req.Header["Accept"], ","), spaceOrComma)
+	acceptGRPCWeb := sliceutils.StringFind(acceptedContentTypes, "application/grpc-web") != -1
+	// The standard gRPC client doesn't actually send an `Accept: application/grpc` header, so always assume
+	// the client accepts gRPC _unless_ it explicitly specifies an `application/grpc-web` accept header
+	// WITHOUT an `application/grpc` accept header.
+	acceptGRPC := !acceptGRPCWeb || sliceutils.StringFind(acceptedContentTypes, "application/grpc") != -1
+
+	// Only consider sending a gRPC response if we are not told to prefer gRPC-Web or the client doesn't support
+	// gRPC-Web.
+	if srvOpts.preferGRPCWeb && isDowngradableMethod && acceptGRPCWeb {
+		acceptGRPC = false
+	}
+
+	// If the client accepts trailers, AND gRPC responses, AND did not set the "Grpc-Web-Only" header,
+	// return the response as a normal gRPC response.
+	if req.Header.Get("TE") == "trailers" && acceptGRPC && len(req.Header[grpcweb.GRPCWebOnlyHeader]) == 0 {
 		grpcSrv.ServeHTTP(w, req)
 		return
 	}
 
-	acceptedContentTypes := strings.FieldsFunc(strings.Join(req.Header["Accept"], ","), spaceOrComma)
-	acceptGRPCWeb := sliceutils.StringFind(acceptedContentTypes, "application/grpc-web") != -1
 	if !acceptGRPCWeb {
 		// Client doesn't support trailers and doesn't accept a response downgraded to gRPC web.
 		http.Error(w, "Client neither supports trailers nor gRPC web responses", http.StatusInternalServerError)
+		return
+	}
+
+	if !isDowngradableMethod {
+		http.Error(w, "Client requires a gRPC-Web response to a method that cannot be downgraded", http.StatusBadRequest)
 		return
 	}
 
@@ -132,7 +151,7 @@ func handleGRPCWeb(w http.ResponseWriter, req *http.Request, validPaths map[stri
 
 // CreateDowngradingHandler takes a gRPC server and a plain HTTP handler, and returns an HTTP handler that has the
 // capability of handling HTTP requests and gRPC requests that may require downgrading the response to gRPC-Web or gRPC-WebSocket.
-func CreateDowngradingHandler(grpcSrv *grpc.Server, httpHandler http.Handler) http.Handler {
+func CreateDowngradingHandler(grpcSrv *grpc.Server, httpHandler http.Handler, opts ...Option) http.Handler {
 	// Only allow paths corresponding to gRPC methods that do not use client streaming for gRPC-Web.
 	validGRPCWebPaths := make(map[string]struct{})
 
@@ -148,19 +167,24 @@ func CreateDowngradingHandler(grpcSrv *grpc.Server, httpHandler http.Handler) ht
 		}
 	}
 
+	var serverOpts options
+	for _, opt := range opts {
+		opt.apply(&serverOpts)
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if isWebSocketUpgrade(req.Header) {
 			handleGRPCWS(w, req, grpcSrv)
 			return
 		}
 
-		if contentType, _ := stringutils.Split2(req.Header.Get("Content-Type"), "+"); contentType != "application/grpc" {
+		if contentType, _ := stringutils.Split2(req.Header.Get("Content-Type"), "+"); contentType != "application/grpc" && contentType != "application/grpc-web" {
 			// Non-gRPC request to the same port.
 			httpHandler.ServeHTTP(w, req)
 			return
 		}
 
-		handleGRPCWeb(w, req, validGRPCWebPaths, grpcSrv)
+		handleGRPCWeb(w, req, validGRPCWebPaths, grpcSrv, &serverOpts)
 	})
 }
 


### PR DESCRIPTION
This adds the following two options to the library:
- On the client side, `ForceDowngrade(true)` instructs the client proxy to downgrade all requests by (a) switching to HTTP/1, (b) omitting the `Accept: application/grpc` header, (c) omitting the `TE: trailers` header, and (d) sending a special header to request a gRPC-Web response (this is to guard against any overzealous gRPC-aware proxies that might "fix" the issues caused by a-c before forwarding to the backend). The server side is extended to recognize this header.
- On the server side, `PreferGRPCWeb(true)` instructs the server to always send a gRPC-Web response when the client indicates that it accepts it _and_ the method is downgradable (i.e., not client- or bidi-streaming).