### PR TITLE
Generate and display more useful error message

### DIFF
--- a/client/ws_proxy.go
+++ b/client/ws_proxy.go
@@ -239,7 +239,7 @@ func (h *http2WebSocketProxy) ServeHTTP(w http.ResponseWriter, req *http.Request
 		CompressionMode: websocket.CompressionDisabled,
 	})
 	if resp != nil {
-		// Not strictly necessary, because the library already replaces resp.Body with a NopCloser,
+		// Not strictly necessary because the library already replaces resp.Body with a NopCloser,
 		// but seems too easy to miss should we switch to a different library.
 		defer func() { _ = resp.Body.Close() }()
 	}

--- a/internal/grpcproto/message.go
+++ b/internal/grpcproto/message.go
@@ -1,0 +1,65 @@
+package grpcproto
+
+import (
+	"bytes"
+	"fmt"
+	"unicode/utf8"
+)
+
+// This code is copied from google.golang.org/grpc@v1.31.1/internal/transport/http_util.go, ll.443-494,
+// and has been adjusted to make the `EncodeGrpcMessage` function exported.
+// The original code is Copyright (c) by the gRPC authors and was distributed under the
+// Apache License, version 2.0.
+
+const (
+	spaceByte   = ' '
+	tildeByte   = '~'
+	percentByte = '%'
+)
+
+// EncodeGrpcMessage is used to encode status code in header field
+// "grpc-message". It does percent encoding and also replaces invalid utf-8
+// characters with Unicode replacement character.
+//
+// It checks to see if each individual byte in msg is an allowable byte, and
+// then either percent encoding or passing it through. When percent encoding,
+// the byte is converted into hexadecimal notation with a '%' prepended.
+func EncodeGrpcMessage(msg string) string {
+	if msg == "" {
+		return ""
+	}
+	lenMsg := len(msg)
+	for i := 0; i < lenMsg; i++ {
+		c := msg[i]
+		if !(c >= spaceByte && c <= tildeByte && c != percentByte) {
+			return encodeGrpcMessageUnchecked(msg)
+		}
+	}
+	return msg
+}
+
+func encodeGrpcMessageUnchecked(msg string) string {
+	var buf bytes.Buffer
+	for len(msg) > 0 {
+		r, size := utf8.DecodeRuneInString(msg)
+		for _, b := range []byte(string(r)) {
+			if size > 1 {
+				// If size > 1, r is not ascii. Always do percent encoding.
+				buf.WriteString(fmt.Sprintf("%%%02X", b))
+				continue
+			}
+
+			// The for loop is necessary even if size == 1. r could be
+			// utf8.RuneError.
+			//
+			// fmt.Sprintf("%%%02X", utf8.RuneError) gives "%FFFD".
+			if b >= spaceByte && b <= tildeByte && b != percentByte {
+				buf.WriteByte(b)
+			} else {
+				buf.WriteString(fmt.Sprintf("%%%02X", b))
+			}
+		}
+		msg = msg[size:]
+	}
+	return buf.String()
+}

--- a/internal/grpcwebsocket/consts.go
+++ b/internal/grpcwebsocket/consts.go
@@ -1,0 +1,7 @@
+package grpcwebsocket
+
+const (
+	// SubprotocolName is the subprotocol for gRPC-websocket specified in the Sec-Websocket-Protocol
+	// header.
+	SubprotocolName = "grpc-ws"
+)

--- a/internal/httputils/error_message.go
+++ b/internal/httputils/error_message.go
@@ -1,0 +1,54 @@
+package httputils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	maxBodyBytes = 1024
+)
+
+var (
+	httpHeaderOptSeparatorRegex = regexp.MustCompile(`;\s*`)
+)
+
+// ExtractResponseError extracts an error from an HTTP response, reading at most 1024 bytes of the
+// response body.
+func ExtractResponseError(resp *http.Response) error {
+	if resp.StatusCode < 400 {
+		return nil
+	}
+	contentTypeFields := httpHeaderOptSeparatorRegex.Split(resp.Header.Get("Content-Type"), 2)
+	if len(contentTypeFields) == 0 {
+		return errors.New(resp.Status)
+	}
+
+	if contentTypeFields[0] != "text/plain" {
+		return fmt.Errorf("%s, content-type %s", resp.Status, contentTypeFields[0])
+	}
+
+	bodyReader := io.LimitReader(resp.Body, maxBodyBytes)
+	contents, err := ioutil.ReadAll(bodyReader)
+	contentsStr := strings.TrimSpace(string(contents))
+	if utf8.Valid(contents) {
+		contentsStr = "invalid UTF-8 characters in response"
+	}
+	if err != nil {
+		if len(contents) == 0 {
+			return fmt.Errorf("%s, error reading response body: %v", resp.Status, err)
+		}
+		return fmt.Errorf("%s: %s, error reading response body after %d bytes: %v", resp.Status, contentsStr, len(contents), err)
+	}
+
+	if len(contentsStr) == 0 {
+		return errors.New(resp.Status)
+	}
+	return fmt.Errorf("%s: %s", resp.Status, contentsStr)
+}

--- a/internal/httputils/error_message.go
+++ b/internal/httputils/error_message.go
@@ -37,17 +37,17 @@ func ExtractResponseError(resp *http.Response) error {
 	bodyReader := io.LimitReader(resp.Body, maxBodyBytes)
 	contents, err := ioutil.ReadAll(bodyReader)
 	contentsStr := strings.TrimSpace(string(contents))
-	if utf8.Valid(contents) {
+	if !utf8.Valid(contents) {
 		contentsStr = "invalid UTF-8 characters in response"
 	}
 	if err != nil {
-		if len(contents) == 0 {
+		if contentsStr == "" {
 			return fmt.Errorf("%s, error reading response body: %v", resp.Status, err)
 		}
 		return fmt.Errorf("%s: %s, error reading response body after %d bytes: %v", resp.Status, contentsStr, len(contents), err)
 	}
 
-	if len(contentsStr) == 0 {
+	if contentsStr == "" {
 		return errors.New(resp.Status)
 	}
 	return fmt.Errorf("%s: %s", resp.Status, contentsStr)


### PR DESCRIPTION
This PR makes multiple changes:
- It properly encodes the gRPC message that we generate for error responses (the encoding code is copied from the grpc-go source code as it is not exported)
- It attempts to read some bytes from a `text/plain` error (>= 400) response in order to provide more useful info for a client.
- It checks for the `Sec-Websocket-Protocol` header only to learn about the intent to establish a gRPC-websocket connection, allowing the server to proactively respond with a meaningful error in case the proxy stripped some other relevant websocket headers.