### PR TITLE
Replace `grpc.WithInsecure()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The first two arguments are the same as for `grpc.DialContext`. The third argume
 config to be used for connecting to the target address. Note that this is different from the usual gRPC API,
 which specifies client TLS config via the `grpc.WithTransportCredentials`. For a plaintext (unencrypted)
 connection to the server, pass a `nil` TLS config; however, this does *not* free you from passing the
-`grpc.WithInsecure()` gRPC dial option.
+`grpc.WithInsecure()` (nor `grpc.WithTransportCredentials(insecure.NewCredentials())`) gRPC dial option.
 
 The last (variadic) parameter specifies options that modify the dialing behavior. You can pass any gRPC dial
 options via `client.DialOpts(...)`; however, the `grpc.WithTransportCredentials` option will not be needed.

--- a/_integration-tests/echo_service_test.go
+++ b/_integration-tests/echo_service_test.go
@@ -33,6 +33,7 @@ import (
 	"golang.stackrox.io/grpc-http1/server"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/examples/features/proto/echo"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -374,7 +375,7 @@ func (c *testCase) Run(t *testing.T, cfg *testConfig) {
 	)
 
 	if c.useProxy {
-		opts := []client.ConnectOption{client.DialOpts(grpc.WithInsecure())}
+		opts := []client.ConnectOption{client.DialOpts(grpc.WithTransportCredentials(insecure.NewCredentials()))}
 		if !c.behindHTTP1ReverseProxy {
 			opts = append(opts, client.ForceHTTP2())
 		}
@@ -382,7 +383,7 @@ func (c *testCase) Run(t *testing.T, cfg *testConfig) {
 
 		cc, err = client.ConnectViaProxy(ctx, targetAddr, nil, opts...)
 	} else {
-		cc, err = grpc.DialContext(ctx, targetAddr, grpc.WithInsecure())
+		cc, err = grpc.DialContext(ctx, targetAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 	require.NoError(t, err, "failed to establish connection")
 


### PR DESCRIPTION
`grpc.WithInsecure()` is deprecated. It is recommended to replace it with `grpc.WithTransportCredentials(insecure.NewCredentials())`. See https://pkg.go.dev/google.golang.org/grpc#WithInsecure.