### PR TITLE
Ensure proxy environment variables are respected.

### DIFF
--- a/client/proxy.go
+++ b/client/proxy.go
@@ -115,7 +115,7 @@ func createTransport(tlsClientConf *tls.Config, forceHTTP2 bool, extraH2ALPNs []
 			TLSClientConfig: tlsClientConf,
 		}
 		if tlsClientConf == nil {
-			transport.DialTLSContext = func(_ context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			transport.DialTLS = func(network, addr string, _ *tls.Config) (net.Conn, error) {
 				return net.Dial(network, addr)
 			}
 		}

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -115,7 +115,7 @@ func createTransport(tlsClientConf *tls.Config, forceHTTP2 bool, extraH2ALPNs []
 			TLSClientConfig: tlsClientConf,
 		}
 		if tlsClientConf == nil {
-			transport.DialTLS = func(network, addr string, _ *tls.Config) (net.Conn, error) {
+			transport.DialTLSContext = func(_ context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
 				return net.Dial(network, addr)
 			}
 		}
@@ -124,6 +124,7 @@ func createTransport(tlsClientConf *tls.Config, forceHTTP2 bool, extraH2ALPNs []
 
 	transport := &http.Transport{
 		ForceAttemptHTTP2: true,
+		Proxy:             http.ProxyFromEnvironment,
 	}
 
 	if tlsClientConf != nil {


### PR DESCRIPTION
Currently, when go-grpc-http1 is used in combination with a proxy, the transport we use for the proxy is not using the default transport.

Hence, `http.ProxyFromEnvironment` is not used as proxy func. This meant that in case go-grpc-http1 in combination with proxies was not working.

Our specific application example was:
```bash
export HTTPS_PROXY=http://localhost:3128
export ROX_ENDPOINT=<some-endpoint>:443
roxctl central whoami
# Successful, but no CONNECT logs within the proxy
```

When forcing the CLI to **not** use go-grpc-http1, it succeeded:
```bash
export HTTPS_PROXY=http://localhost:3128
export ROX_ENDPOINT=<some-endpoint>:443
roxctl central whoami --direct-grpc

# Proxy logs show HTTP CONNECT from roxctl for the central <some-endpoint>:443
2023/03/22 03:40:45| Service Name: squid
2023/03/22 03:40:45| pinger: Initialising ICMP pinger ...
1679456470.792   2529 ::1 TCP_TUNNEL/200 794190 CONNECT <endpoint>:443 - HIER_DIRECT/<IP> -
```

The PR fixes the HTTP transport to include proxy information from the environment, hence making go-grpc-http1 work with a proxy.