### PR TITLE
[fixup] - set the hostname

### DIFF
--- a/client/proxy.go
+++ b/client/proxy.go
@@ -26,15 +26,16 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
+
 	"golang.stackrox.io/grpc-http1/internal/grpcproto"
 	"golang.stackrox.io/grpc-http1/internal/grpcweb"
 	"golang.stackrox.io/grpc-http1/internal/httputils"
 	"golang.stackrox.io/grpc-http1/internal/pipeconn"
 	"golang.stackrox.io/grpc-http1/internal/stringutils"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials"
 )
 
 func modifyResponse(resp *http.Response) error {
@@ -103,6 +104,7 @@ func createReverseProxy(endpoint string, transport http.RoundTripper, insecure, 
 				req.Header.Set("Content-Type", contentType)
 			}
 
+			req.Host = endpoint
 			req.URL.Scheme = scheme
 			req.URL.Host = endpoint
 		},


### PR DESCRIPTION
We need to set the hostname to the scanner API endpiont for the proxy to connect correctly.