### PR TITLE
bump required go version to 1.21 for main module and 1.22 for tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: ~1.19
+          go-version: ~1.22
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1

--- a/_integration-tests/go.mod
+++ b/_integration-tests/go.mod
@@ -1,6 +1,6 @@
 module golang.stackrox.io/grpc-http1/_integration-tests
 
-go 1.19
+go 1.21.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/_integration-tests/go.sum
+++ b/_integration-tests/go.sum
@@ -5,6 +5,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
 github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.stackrox.io/grpc-http1
 
-go 1.19
+go 1.21.0
 
 require (
 	github.com/coder/websocket v1.8.12

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
 github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module golang.stackrox.io/grpc-http1/tools
 
-go 1.18
+go 1.22.0
 
 require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616


### PR DESCRIPTION
Go 1.21 brought go toolchain changes, which makes working with Go versions below 1.21 pretty annoying...

Also, 1.19 is pretty old at this point, so why not bump the minimum required version to 1.21. No need for 1.22 nor 1.23, as there is no reason someone using 1.21 cannot use this.

I bumped tools/go.mod to 1.22, though, due to https://github.com/stackrox/go-grpc-http1/pull/215