### PR TITLE
chore: revert toolchain to go 1.23

### DIFF
--- a/_integration-tests/go.mod
+++ b/_integration-tests/go.mod
@@ -1,7 +1,7 @@
 module golang.stackrox.io/grpc-http1/_integration-tests
 
 go 1.22.5
-toolchain go1.24.1
+toolchain go1.23.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module golang.stackrox.io/grpc-http1
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.23.7
 
 require (
 	github.com/coder/websocket v1.8.13


### PR DESCRIPTION
A recent dependabot bug bumped the toolchain where it was likely not required.
Reverting it to what it was before.